### PR TITLE
Added support for multifactor authentication login

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rh-cli
 
-**rh-cli** is a simple Windows command line interface for trading stocks on Robinhood. It utilizes a more comprehensive version of [RobinhoodNet](https://github.com/itsff/RobinhoodNet).
+**rh-cli** is a simple .NET/Mono command line interface for trading stocks on Robinhood. It utilizes a more comprehensive version of [RobinhoodNet](https://github.com/itsff/RobinhoodNet).
 
 Neither this project nor the creator is affiliated with Robinhood Financial LLC.
 

--- a/RobinhoodNet/Raw/RawRobinhoodClient.cs
+++ b/RobinhoodNet/Raw/RawRobinhoodClient.cs
@@ -18,6 +18,7 @@ namespace BasicallyMe.RobinhoodNet.Raw
         static readonly string MULTIFACTOR_AUTH_URL = "https://api.robinhood.com/mfa/";
         static readonly string PASSWORD_RESET_URL = "https://api.robinhood.com/password_reset/request/";
         static readonly string PASSWORD_CHANGE_URL = "https://api.robinhood.com/password_change/";
+        static readonly string OAUTH_TOKEN_URL = "https://api.robinhood.com/oauth2/token/";
 
         // User Info
         static readonly string INVESTMENT_PROFILE_URL = "https://api.robinhood.com/user/investment_profile/";
@@ -66,9 +67,10 @@ namespace BasicallyMe.RobinhoodNet.Raw
         // Settings
         static readonly string SETTINGS_NOTIFICATIONS_URL = "https://api.robinhood.com/settings/notifications/";
 
+
         public RawRobinhoodClient ()
         {
-            var handler = new HttpClientHandler();
+            var handler = new HttpClientHandler ();
             if (handler.SupportsAutomaticDecompression)
             {
                 handler.AutomaticDecompression = DecompressionMethods.GZip |
@@ -84,6 +86,7 @@ namespace BasicallyMe.RobinhoodNet.Raw
             _httpClient.DefaultRequestHeaders.Add("X-Robinhood-API-Version", "1.103.0");
             _httpClient.DefaultRequestHeaders.Add("Connection", "keep-alive");
             _httpClient.DefaultRequestHeaders.Add("User-Agent", "Robinhood/823 (iPhone; iOS 7.1.2; Scale/2.00)");
+           
         }
 
 
@@ -99,6 +102,7 @@ namespace BasicallyMe.RobinhoodNet.Raw
             JObject result = JObject.Parse(content);
             return result;
         }
+
 
         Task<HttpResponseMessage>
         doPost_NativeResponse (Uri uri, IEnumerable<KeyValuePair<string, string>> pairs = null)

--- a/RobinhoodNet/Raw/RawRobinhoodClient_Auth.cs
+++ b/RobinhoodNet/Raw/RawRobinhoodClient_Auth.cs
@@ -7,40 +7,90 @@ namespace BasicallyMe.RobinhoodNet.Raw
 {
     public partial class RawRobinhoodClient
     {
-        string _authToken;
-        public string AuthToken
+        RobinhoodAuthToken _authToken;
+
+        // oAuth constants
+        static readonly string OAUTH_GRANT_TYPE = "password";
+        static readonly string OAUTH_SCOPE = "internal";
+        static readonly string OAUTH_CLIENT_ID = "c82SH0WZOsabOXGP2sxqcj34FxkvfnWRZBKlBjFS";
+
+
+        public RobinhoodAuthToken AuthToken
         {
             get { return _authToken; }
             private set
             {
                 _authToken = value;
                 _httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue(
-                    "Token",
-                    _authToken);
+                    _authToken.TokenType.ToString(),
+                    _authToken.Value);
             }
         }
 
-        public async Task<bool>
-        Authenticate (string userName, string password)
+        public async Task<RobinhoodAuthResponse>
+        MFAAuthenticate (RobinhoodAuthRequest authRequest)
+        {
+            try {
+                var form = new Dictionary<String, String> () {
+                    {"grant_type", OAUTH_GRANT_TYPE},
+                    {"scope", OAUTH_SCOPE},
+                    {"client_id", OAUTH_CLIENT_ID},
+                    {"mfa_code",((authRequest.RequestType == RobinhoodAuthRequestType.mfa) ? authRequest.MFA_Code : "")},
+                    {"backup_code", ((authRequest.RequestType == RobinhoodAuthRequestType.backupcode) ? authRequest.Backup_Code : "")},
+                    {"username", authRequest.Username},
+                    {"password", authRequest.Password}
+                };
+
+                var rawResponse = await doPost (OAUTH_TOKEN_URL, form);
+
+                RobinhoodAuthResponse response = null;
+
+                if (rawResponse ["access_token"] != null) {
+                    var token = new RobinhoodAuthToken (RobinhoodAuthTokenType.Bearer, rawResponse ["access_token"].ToString ());
+                    this.AuthToken = token;
+                    response = new RobinhoodAuthResponse (RobinhoodAuthResponseType.token, token);
+                } else {
+                    response = new RobinhoodAuthResponse (RobinhoodAuthResponseType.none);
+                }
+
+                return response;                
+            } catch {
+                return new RobinhoodAuthResponse (RobinhoodAuthResponseType.none);
+            }
+        }
+
+        public async Task<RobinhoodAuthResponse>
+        Authenticate (RobinhoodAuthRequest authRequest)
         {
             try
             {
-                var auth = await doPost(LOGIN_URL, new Dictionary<string, string>
+                var rawResponse = await doPost(LOGIN_URL, new Dictionary<string, string>
                 {
-                    { "username", userName },
-                    { "password", password }
+                    { "username", authRequest.Username },
+                    { "password", authRequest.Password }
                 });
 
-                this.AuthToken = auth["token"].ToString();
+                RobinhoodAuthResponse response = null;
+
+                if (rawResponse ["mfa_required"] != null) {
+                    response = new RobinhoodAuthResponse (RobinhoodAuthResponseType.mfa);
+                } else if (rawResponse ["token"] != null) {
+                    var token = new RobinhoodAuthToken(rawResponse ["token"].ToString ());
+                    response = new RobinhoodAuthResponse (RobinhoodAuthResponseType.token, token);
+                    this.AuthToken = token;
+                } else {
+                    response = new RobinhoodAuthResponse (RobinhoodAuthResponseType.none);
+                }
+
+                return response;
             }
             catch
             {
-                return false;
+                return new RobinhoodAuthResponse (RobinhoodAuthResponseType.none);
             }
-            return true;
         }
 
-        public async Task<bool> Authenticate (string token)
+        public async Task<bool> Authenticate (RobinhoodAuthToken token)
         {
             this.AuthToken = token;
 

--- a/RobinhoodNet/RobinhoodAuthRequest.cs
+++ b/RobinhoodNet/RobinhoodAuthRequest.cs
@@ -1,0 +1,43 @@
+﻿using System;
+namespace BasicallyMe.RobinhoodNet
+{
+    public enum RobinhoodAuthRequestType
+    {
+        mfa,
+        password,
+        backupcode
+    }
+
+    public class RobinhoodAuthRequest
+    {
+        protected RobinhoodAuthRequestType _requestType;
+        public RobinhoodAuthRequestType RequestType {
+            get { return this._requestType; }
+            set { this._requestType = value; }
+        }
+
+        protected string _username;
+        protected string _password;
+        protected string _mfa_code;
+        protected string _backup_code;
+
+        public string Username { get { return _username; } }
+        public string Password { get { return _password; } }
+        public string MFA_Code { get { return _mfa_code; } set { _mfa_code = value; } }
+        public string Backup_Code { get { return _backup_code; } set { _backup_code = value; } }
+
+        public RobinhoodAuthRequest (RobinhoodAuthRequestType requestType, string username, string password)
+        {
+            this._requestType = requestType;
+            this._username = username;
+            this._password = password;
+        }
+
+        public RobinhoodAuthRequest (string username, string password)
+        {
+            this._username = username;
+            this._password = password;
+            this._requestType = RobinhoodAuthRequestType.password;
+        }
+    }
+}

--- a/RobinhoodNet/RobinhoodAuthResponse.cs
+++ b/RobinhoodNet/RobinhoodAuthResponse.cs
@@ -1,0 +1,34 @@
+﻿using System;
+namespace BasicallyMe.RobinhoodNet
+{
+    public enum RobinhoodAuthResponseType
+    {
+        mfa,
+        token,
+        none
+    }
+
+    public class RobinhoodAuthResponse
+    {
+        protected RobinhoodAuthResponseType _responseType;
+        public RobinhoodAuthResponseType ResponseType {
+            get { return this._responseType; }
+        }
+
+        protected RobinhoodAuthToken _value = null;
+        public RobinhoodAuthToken Value {
+            get { return this._value; }
+        }
+
+        public RobinhoodAuthResponse (RobinhoodAuthResponseType responseType, RobinhoodAuthToken value)
+        {
+            this._responseType = responseType;
+            this._value = value;
+        }
+
+        public RobinhoodAuthResponse (RobinhoodAuthResponseType responseType)
+        {
+            this._responseType = responseType;
+        }
+    }
+}

--- a/RobinhoodNet/RobinhoodAuthToken.cs
+++ b/RobinhoodNet/RobinhoodAuthToken.cs
@@ -1,0 +1,44 @@
+﻿using System;
+namespace BasicallyMe.RobinhoodNet
+{
+    public enum RobinhoodAuthTokenType
+    {
+        Bearer,
+        Token
+    }
+
+    public class RobinhoodAuthToken
+    {
+        protected RobinhoodAuthTokenType _tokenType = RobinhoodAuthTokenType.Token;
+        public RobinhoodAuthTokenType TokenType {
+            get {
+                return _tokenType;
+            }
+            set {
+                _tokenType = value;
+            }
+        }
+
+        protected string _value;
+        public string Value {
+            get { return _value; }
+            set { _value = value; }
+        }
+
+        public RobinhoodAuthToken (string value)
+        {
+            _value = value;
+        }
+
+        public RobinhoodAuthToken (RobinhoodAuthTokenType tokenType, string value)
+        {
+            _tokenType = tokenType;
+            _value = value;
+        }
+
+        [Newtonsoft.Json.JsonConstructor]
+        public RobinhoodAuthToken ()
+        {
+        }
+    }
+}

--- a/RobinhoodNet/RobinhoodClient.cs
+++ b/RobinhoodNet/RobinhoodClient.cs
@@ -36,27 +36,48 @@ namespace BasicallyMe.RobinhoodNet
 
         public RobinhoodClient ()
         {
-            _rawClient = new Raw.RawRobinhoodClient();
+            _rawClient = new Raw.RawRobinhoodClient ();
         }
 
-        public RobinhoodClient(string token)
+        public RobinhoodClient (RobinhoodAuthToken token)
         {
-            _rawClient = new Raw.RawRobinhoodClient();
-            Authenticate(token);
+            _rawClient = new Raw.RawRobinhoodClient ();
+            Authenticate (token);
         }
-        public string AuthToken
+
+        public RobinhoodClient (string token)
         {
+            _rawClient = new Raw.RawRobinhoodClient ();
+            Authenticate (new RobinhoodAuthToken (token));
+        }
+
+        public RobinhoodAuthToken AuthToken {
             get { return _rawClient.AuthToken; }
         }
 
-        public bool Authenticate (string userName, string password)
+        public RobinhoodAuthResponse MFAAuthenticate (RobinhoodAuthRequest authRequest)
         {
-            return _rawClient.Authenticate(userName, password).Result;
+            return _rawClient.MFAAuthenticate (authRequest).Result;
+        }
+
+        public RobinhoodAuthResponse Authenticate (RobinhoodAuthRequest authRequest)
+        {
+            return _rawClient.Authenticate(authRequest).Result;
+        }
+
+        public RobinhoodAuthResponse Authenticate (string userName, string password)
+        {
+            return Authenticate (new RobinhoodAuthRequest (userName, password));
+        }
+
+        public bool Authenticate (RobinhoodAuthToken token)
+        {
+            return _rawClient.Authenticate(token).Result;
         }
 
         public bool Authenticate (string token)
         {
-            return _rawClient.Authenticate(token).Result;
+            return Authenticate (new RobinhoodAuthToken(token));
         }
 
         public bool isAuthenticated

--- a/RobinhoodNet/RobinhoodNet.csproj
+++ b/RobinhoodNet/RobinhoodNet.csproj
@@ -73,6 +73,9 @@
     <Compile Include="UserIdInfo.cs" />
     <Compile Include="UserInvestmentProfile.cs" />
     <Compile Include="Watchlist.cs" />
+    <Compile Include="RobinhoodAuthResponse.cs" />
+    <Compile Include="RobinhoodAuthRequest.cs" />
+    <Compile Include="RobinhoodAuthToken.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Import Project="..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
@@ -81,10 +84,6 @@
     <None Include="LICENSE.txt" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\portable-net45+win8\System.Net.Http.Extensions.dll</HintPath>
       <Private>True</Private>
@@ -93,13 +92,16 @@
       <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\portable-net45+win8\System.Net.Http.Primitives.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.1\lib\portable-net45+win8+wpa81+wp8\Newtonsoft.Json.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ProjectExtensions>
     <MonoDevelop>
       <Properties>
         <Policies>
-          <TextStylePolicy FileWidth="120" inheritsSet="VisualStudio" inheritsScope="text/plain" scope="text/plain" />
-          <CSharpFormattingPolicy IndentBlocksInsideExpressions="True" AnonymousMethodBraceStyle="NextLine" PropertyBraceStyle="NextLine" PropertyGetBraceStyle="NextLine" PropertySetBraceStyle="NextLine" EventBraceStyle="NextLine" EventAddBraceStyle="NextLine" EventRemoveBraceStyle="NextLine" StatementBraceStyle="NextLine" ElseNewLinePlacement="NewLine" CatchNewLinePlacement="NewLine" FinallyNewLinePlacement="NewLine" WhileNewLinePlacement="DoNotCare" ArrayInitializerWrapping="DoNotChange" ArrayInitializerBraceStyle="NextLine" BeforeMethodCallParentheses="False" NewLineBeforeConstructorInitializerColon="NewLine" NewLineAfterConstructorInitializerColon="SameLine" NewParentheses="False" SpacesBeforeBrackets="False" SpacesBeforeArrayDeclarationBrackets="True" MethodCallArgumentWrapping="WrapIfTooLong" NewLineAferMethodCallOpenParentheses="NewLine" AlignToFirstMethodCallArgument="True" MethodDeclarationParameterWrapping="WrapIfTooLong" NewLineAferMethodDeclarationOpenParentheses="NewLine" MethodDeclarationClosingParenthesesOnNewLine="NewLine" AlignToFirstMethodDeclarationParameter="False" IndexerDeclarationParameterWrapping="WrapIfTooLong" NewLineAferIndexerDeclarationOpenBracket="NewLine" inheritsSet="Mono" inheritsScope="text/x-csharp" scope="text/x-csharp" />
+          <TextStylePolicy TabWidth="4" TabsToSpaces="True" IndentWidth="4" RemoveTrailingWhitespace="True" NoTabsAfterNonTabs="False" EolMarker="Native" FileWidth="120" inheritsSet="VisualStudio" inheritsScope="text/plain" scope="text/plain" />
+          <CSharpFormattingPolicy IndentBlock="True" IndentBraces="False" IndentSwitchSection="False" IndentSwitchCaseSection="True" LabelPositioning="OneLess" NewLinesForBracesInTypes="True" NewLinesForBracesInMethods="True" NewLinesForBracesInProperties="False" NewLinesForBracesInAccessors="False" NewLinesForBracesInAnonymousMethods="False" NewLinesForBracesInControlBlocks="False" NewLinesForBracesInAnonymousTypes="False" NewLinesForBracesInObjectCollectionArrayInitializers="False" NewLinesForBracesInLambdaExpressionBody="False" NewLineForElse="False" NewLineForCatch="False" NewLineForFinally="False" NewLineForMembersInObjectInit="False" NewLineForMembersInAnonymousTypes="False" NewLineForClausesInQuery="False" SpacingAfterMethodDeclarationName="True" SpaceWithinMethodDeclarationParenthesis="False" SpaceBetweenEmptyMethodDeclarationParentheses="False" SpaceAfterMethodCallName="True" SpaceWithinMethodCallParentheses="False" SpaceBetweenEmptyMethodCallParentheses="False" SpaceAfterControlFlowStatementKeyword="True" SpaceWithinExpressionParentheses="False" SpaceWithinCastParentheses="False" SpaceWithinOtherParentheses="False" SpaceAfterCast="False" SpacesIgnoreAroundVariableDeclaration="False" SpaceBeforeOpenSquareBracket="True" SpaceBetweenEmptySquareBrackets="False" SpaceWithinSquareBrackets="False" SpaceAfterColonInBaseTypeDeclaration="True" SpaceAfterComma="True" SpaceAfterDot="False" SpaceAfterSemicolonsInForStatement="True" SpaceBeforeColonInBaseTypeDeclaration="True" SpaceBeforeComma="False" SpaceBeforeDot="False" SpaceBeforeSemicolonsInForStatement="False" SpacingAroundBinaryOperator="Single" WrappingPreserveSingleLine="True" WrappingKeepStatementsOnSingleLine="True" PlaceSystemDirectiveFirst="True" inheritsSet="Mono" inheritsScope="text/x-csharp" scope="text/x-csharp" />
           <TextStylePolicy inheritsSet="null" scope="text/x-csharp" />
           <TextStylePolicy inheritsSet="null" scope="text/x-fsharp" />
           <FSharpFormattingPolicy scope="text/x-fsharp">

--- a/RobinhoodNet/packages.config
+++ b/RobinhoodNet/packages.config
@@ -3,5 +3,5 @@
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="portable-net45+win+wp80+MonoTouch10+MonoAndroid10+Unsupported" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="portable45-net45+win8" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="portable45-net45+win8" />
+  <package id="Newtonsoft.Json" version="10.0.1" targetFramework="portable45-net45+win8" />
 </packages>

--- a/rh-cli/Rhcli_Auth.cs
+++ b/rh-cli/Rhcli_Auth.cs
@@ -26,54 +26,102 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using BasicallyMe.RobinhoodNet;
+using Newtonsoft.Json;
 
 namespace rh_cli
 {
-    partial class Program
-    {
-        protected static string symbol;
+	partial class Program
+	{
+		protected static string symbol;
 
-        static readonly string __tokenFile = System.IO.Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-        "RobinhoodNet",
-        "token");
+		static readonly string __tokenFile = System.IO.Path.Combine(
+		Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+		"RobinhoodNet",
+		"token");
 
-        static bool Auth(RobinhoodClient client)
-        {
+		static bool MFA_Auth(RobinhoodClient client, RobinhoodAuthRequest authRequest)
+		{
+			Console.Write("use mfa code or backup code (enter mfa or backup): ");
+			var mfa_or_backup = Console.ReadLine();
+			if (mfa_or_backup.Contains("mfa"))
+			{
+				authRequest.RequestType = RobinhoodAuthRequestType.mfa;
+				Console.Write("mfa code: ");
+				authRequest.MFA_Code = Console.ReadLine();
+			}
+			else if (mfa_or_backup.Contains("backup"))
+			{
+				authRequest.RequestType = RobinhoodAuthRequestType.backupcode;
+				Console.Write("backup code: ");
+				authRequest.Backup_Code = Console.ReadLine();
+			}
+			else
+			{
+				return false;
+			}
 
-            if (System.IO.File.Exists(__tokenFile))
-            {
-                var token = System.IO.File.ReadAllText(__tokenFile);
-                if (!client.Authenticate(token))
-                {
-                    if (System.IO.File.Exists(__tokenFile))
-                    {
-                        System.IO.File.Delete(__tokenFile);
-                    }
-                    return false;
-                }
-                return true;
-            }
-            else
-            {
-                Console.Write("username: ");
-                string userName = Console.ReadLine();
+			RobinhoodAuthResponse response = client.MFAAuthenticate(authRequest);
+			return (response.ResponseType == RobinhoodAuthResponseType.token);
+		}
 
-                Console.Write("password: ");
-                string password = Console.ReadLine();
 
-                if (!client.Authenticate(userName, password))
-                {
-                    return false;
-                }
+		static bool Auth(RobinhoodClient client)
+		{
 
-                System.IO.Directory.CreateDirectory(
-                    System.IO.Path.GetDirectoryName(__tokenFile));
+			if (System.IO.File.Exists(__tokenFile))
+			{
+				try
+				{
+					var token = (RobinhoodAuthToken)JsonConvert.DeserializeObject(System.IO.File.ReadAllText(__tokenFile), typeof(RobinhoodAuthToken));
+					if (!client.Authenticate(token))
+					{
+						if (System.IO.File.Exists(__tokenFile))
+						{
+							System.IO.File.Delete(__tokenFile);
+						}
+						return false;
+					}
+					return true;
+				}
+				catch
+				{
+					if (System.IO.File.Exists(__tokenFile))
+					{
+						System.IO.File.Delete(__tokenFile);
+					}
+					return false;
+				}
+			}
+			else
+			{
+				
+				Console.Write("username: ");
+				string userName = Console.ReadLine();
 
-                System.IO.File.WriteAllText(__tokenFile, client.AuthToken);
-                return true;
-            }
-        }
-    }
+				Console.Write("password: ");
+				string password = Console.ReadLine();
+
+				RobinhoodAuthRequest authRequest = new RobinhoodAuthRequest(RobinhoodAuthRequestType.password, userName, password);
+				RobinhoodAuthResponse authResponse = client.Authenticate(authRequest);
+				if (authResponse.ResponseType == RobinhoodAuthResponseType.none)
+				{
+					return false;
+				}
+				else if (authResponse.ResponseType == RobinhoodAuthResponseType.mfa)
+				{
+					if (!MFA_Auth(client, authRequest))
+					{
+						return false;
+					}
+				}
+
+				System.IO.Directory.CreateDirectory(
+					System.IO.Path.GetDirectoryName(__tokenFile));
+
+				System.IO.File.WriteAllText(__tokenFile, JsonConvert.SerializeObject(client.AuthToken));
+				return true;
+			}
+		}
+	}
 }
 

--- a/rh-cli/packages.config
+++ b/rh-cli/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="10.0.1" targetFramework="net452" />
+</packages>

--- a/rh-cli/rh-cli.csproj
+++ b/rh-cli/rh-cli.csproj
@@ -41,6 +41,9 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />
@@ -53,6 +56,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\RobinhoodNet\RobinhoodNet.csproj">


### PR DESCRIPTION
Added support for multifactor authentication with either an SMS code or a backup code. If the initial authentication attempt returns a object with the "mfa_required" set to true, it will prompt the user for either an SMS code or a backup code. 

To differentiate vanilla username/password logins from those requiring an MFA code I created new classes to represent an authentication request, response and the token itself.